### PR TITLE
fix x-raw-image://urls

### DIFF
--- a/google_images_search/google_api.py
+++ b/google_images_search/google_api.py
@@ -108,7 +108,8 @@ class GoogleCustomSearch(object):
                     continue
                 except requests.exceptions.SSLError:
                     continue
-
+                except requests.exceptions.InvalidSchema:
+                    continue
             yield image['link']
 
 


### PR DESCRIPTION
    raise InvalidSchema("No connection adapters were found for {!r}".format(url))
requests.exceptions.InvalidSchema: No connection adapters were found for 'x-raw-image:///85a85cbd50837bd403e7cbfb85e1553e01e203ba741f9776b90f016fe89bbe4d'