### PR TITLE
Add imgColorType param for google api

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,8 @@ _search_params = {
     'fileType': 'jpg|gif|png',
     'imgType': 'clipart|face|lineart|news|photo',
     'imgSize': 'huge|icon|large|medium|small|xlarge|xxlarge',
-    'imgDominantColor': 'black|blue|brown|gray|green|pink|purple|teal|white|yellow',
+    'imgDominantColor': 'black|blue|brown|gray|green|orange|pink|purple|red|teal|white|yellow',
+    'imgColorType': 'color|gray|mono|trans',
     'rights': 'cc_publicdomain|cc_attribute|cc_sharealike|cc_noncommercial|cc_nonderived'
 }
 

--- a/google_images_search/google_api.py
+++ b/google_images_search/google_api.py
@@ -28,6 +28,7 @@ class GoogleCustomSearch(object):
             'fileType': None,
             'safe': 'off',
             'imgDominantColor': None,
+            'imgColorType': None,
             'rights': None
         }
 

--- a/tests/test_google_api.py
+++ b/tests/test_google_api.py
@@ -24,6 +24,7 @@ class TestGoogleApi(unittest.TestCase):
             'fileType': None,
             'safe': 'off',
             'imgDominantColor': None,
+            'imgColorType': None,
             'rights': None
         })
 


### PR DESCRIPTION
I needed imgColorType parameter to looking for transparent images.

I added it for google api (I didn't add it for CLI)

Source: https://developers.google.com/custom-search/v1/reference/rest/v1/cse/list#body.QUERY_PARAMETERS.img_color_type