### PR TITLE
Enable search param - imgSize in lowercase entry during programmatic usage

### DIFF
--- a/README.md
+++ b/README.md
@@ -78,17 +78,21 @@ from google_images_search import GoogleImagesSearch
 # or you can set environment variables: GCS_DEVELOPER_KEY, GCS_CX
 gis = GoogleImagesSearch('your_dev_api_key', 'your_project_cx')
 
-# define search params:
+# define search params
+# option for commonly used search param are shown below for easy reference.
+# For param marked with '##':
+#   - Multiselect is currently not feasible. Choose ONE option only
+#   - This param can also be omitted from _search_params if you do not wish to define any value
 _search_params = {
     'q': '...',
     'num': 10,
-    'safe': 'high|medium|off',
     'fileType': 'jpg|gif|png',
-    'imgType': 'clipart|face|lineart|news|photo',
-    'imgSize': 'huge|icon|large|medium|small|xlarge|xxlarge',
-    'imgDominantColor': 'black|blue|brown|gray|green|orange|pink|purple|red|teal|white|yellow',
-    'imgColorType': 'color|gray|mono|trans',
-    'rights': 'cc_publicdomain|cc_attribute|cc_sharealike|cc_noncommercial|cc_nonderived'
+    'rights': 'cc_publicdomain|cc_attribute|cc_sharealike|cc_noncommercial|cc_nonderived',
+    'safe': 'active|high|medium|off|safeUndefined', ##
+    'imgType': 'clipart|face|lineart|stock|photo|animated|imgTypeUndefined', ##
+    'imgSize': 'huge|icon|large|medium|small|xlarge|xxlarge|imgSizeUndefined', ##
+    'imgDominantColor': 'black|blue|brown|gray|green|orange|pink|purple|red|teal|white|yellow|imgDominantColorUndefined', ##
+    'imgColorType': 'color|gray|mono|trans|imgColorTypeUndefined' ##
 }
 
 # this will only search for images:

--- a/google_images_search/google_api.py
+++ b/google_images_search/google_api.py
@@ -59,6 +59,9 @@ class GoogleCustomSearch(object):
 
         for key, value in self._search_params_keys.items():
             params_value = params.get(key)
+            if key == "imgSize":
+                params_value = params_value.upper()
+
             if params_value:
                 # take user defined param value if defined
                 search_params[key] = params_value

--- a/google_images_search/google_api.py
+++ b/google_images_search/google_api.py
@@ -61,7 +61,7 @@ class GoogleCustomSearch(object):
             params_value = params.get(key)
 
             if params_value:
-                if key == "imgSize":
+                if key == "imgSize" and params_value != "imgSizeUndefined":
                     params_value = params_value.upper()
                 # take user defined param value if defined
                 search_params[key] = params_value

--- a/google_images_search/google_api.py
+++ b/google_images_search/google_api.py
@@ -59,10 +59,10 @@ class GoogleCustomSearch(object):
 
         for key, value in self._search_params_keys.items():
             params_value = params.get(key)
-            if key == "imgSize":
-                params_value = params_value.upper()
 
             if params_value:
+                if key == "imgSize":
+                    params_value = params_value.upper()
                 # take user defined param value if defined
                 search_params[key] = params_value
             elif value:

--- a/tests/test_google_api.py
+++ b/tests/test_google_api.py
@@ -74,7 +74,7 @@ class TestGoogleApi(unittest.TestCase):
             'safe': 'high',
             'fileType': 'jpg',
             'imgType': 'clipart',
-            'imgSize': 'huge',
+            'imgSize': 'HUGE',
             'searchType': 'image',
             'imgDominantColor': 'black'
         }


### PR DESCRIPTION
To allow `imgSize` to be specified in lowercase just as other search params. It is not clear that this particular param needs to  be in all uppercase. Readme also shows the input for this param is in lowercase. 

User will not notice this until hits error in terminal with message
```
TypeError: Parameter "imgSize" value "medium" is not an allowed value in "['imgSizeUndefined', 'HUGE', 'ICON', 'LARGE', 'MEDIUM', 'SMALL', 'XLARGE', 'XXLARGE']"
```


Notice for CLI usage [ `cli.py` line 60-61 ]
```
    if imagesize:
        imagesize = imagesize.upper()
```
there’s a special handling of this param to Uppercase. It will be good to allow the same special handling done internally in `fetch_resize_save.py` as well if user choose the programmatic usage